### PR TITLE
adds meetings page w/ proposed agenda for kickoff

### DIFF
--- a/meetings/index.md
+++ b/meetings/index.md
@@ -1,0 +1,39 @@
+---
+title: Meetings
+layout: page
+---
+
+# Kickoff
+
+Jan 28, 2021. [8am PT / 11am ET / 4pm GMT / 5pm CET](https://www.starts-at.com/event/2649073776)
+
+*Purpose*: Launch the project & ensure all teams have foundation to get started.
+
+*Attendees*: Alfa Cohort teams, CZI Imaging team, napari core team
+
+*Agenda*:
+
+- 0:00 - Welcome (@neuromusic)
+- 0:10 - Team Presentations
+- 0:35 - UXR Read-out (@LCObus)
+- 0:45 - Napari Overview (@sofroniewn)
+- 0:55 - Building a Plugin (@tlambert03)
+- 1:20 - Open Discussion
+- 1:30 - Fin
+
+
+# Co-design Workshop
+
+Feb TBD: Co-design workshop
+
+*Purpose*: Get feedback on napari plugin developer tools and ideate on opportunities for the napari "App Store".
+
+*Attendees*: Alfa Cohort teams, CZI Imaging team
+
+# Demo Day
+
+[Tentative] April 29, 2021. 3-4 hours
+
+*Purpose*: Showcase the progress of the Alfa Cohort teams & celebrate the official end of the collaboration.
+
+*Attendees*: Alfa Cohort teams, CZI Science, napari community

--- a/meetings/index.md
+++ b/meetings/index.md
@@ -14,7 +14,7 @@ Jan 28, 2021. [8am PT / 11am ET / 4pm GMT / 5pm CET](https://www.starts-at.com/e
 *Agenda*:
 
 - 0:00 - Welcome (@neuromusic)
-- 0:10 - Team Presentations
+- 0:10 - Team Presentations (3 minutes per team)
 - 0:35 - UXR Read-out (@LCObus)
 - 0:45 - Napari Overview (@sofroniewn)
 - 0:55 - Building a Plugin (@tlambert03)

--- a/projects/index.md
+++ b/projects/index.md
@@ -1,5 +1,5 @@
 ---
-title: projects
+title: Projects
 layout: page
 ---
 


### PR DESCRIPTION
This PR adds a "meetings" page, including a proposed agenda for next week's kickoff meeting.

The agenda is open to discussion. There's a lot we want to fit in to a relatively short meeting. 

@LCObus: Does 10 minutes to present on UXR readout sound good?
@sofroniewn: How does 10 minutes for napari overview & roadmap sound?
@tlambert03: Is 25 minutes good for you?